### PR TITLE
Specify package files in 'dependencies' of MLHUB.yaml

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -10,7 +10,8 @@ meta:
   author       : Graham.Williams@togaware.com
   url          : https://github.com/gjwgit/beeswarm
 dependencies :
-  cran: ggbeeswarm, rattle, randomForest
+  cran  : ggbeeswarm, rattle, randomForest
+  files : demo.R, print.R, README.md
 commands:
   demo  : Step through examples of bee swarm plots.
   print : Display the code used for the demo.


### PR DESCRIPTION
Package file specification is now available at mlhubber/mlhub@f21a442